### PR TITLE
Enhance background refinement with manual selection tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CutPro Studio - Recorte inteligente para e-commerce</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js"></script>
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <div class="app-shell">
+    <aside class="sidebar">
+      <div class="branding">
+        <div class="logo-circle">C</div>
+        <div>
+          <h1>CutPro Studio</h1>
+          <p>Still perfeito em minutos</p>
+        </div>
+      </div>
+      <section class="sidebar-section">
+        <h2>Upload</h2>
+        <p>Arraste e solte arquivos JPG, PNG, WEBP ou GIF ou use o botão abaixo.</p>
+        <label class="upload-button">
+          <input id="fileInput" type="file" accept="image/png, image/jpeg, image/webp, image/gif" multiple>
+          Selecionar imagens
+        </label>
+        <div id="dropZone" class="drop-zone">
+          <span>Arraste as imagens aqui</span>
+        </div>
+      </section>
+      <section class="sidebar-section">
+        <h2>Preset de proporção</h2>
+        <div class="ratio-grid" id="ratioButtons">
+          <button data-ratio="1:1" class="ratio-btn active">1:1</button>
+          <button data-ratio="4:5" class="ratio-btn">4:5</button>
+          <button data-ratio="16:9" class="ratio-btn">16:9</button>
+          <button data-ratio="3:4" class="ratio-btn">3:4</button>
+          <button data-ratio="5:2" class="ratio-btn">5:2</button>
+          <button data-ratio="free" class="ratio-btn">Livre</button>
+        </div>
+        <div class="custom-dimensions">
+          <label>
+            Largura
+            <input type="number" id="customWidth" min="200" max="4000" value="1200">
+          </label>
+          <label>
+            Altura
+            <input type="number" id="customHeight" min="200" max="4000" value="1200">
+          </label>
+        </div>
+      </section>
+      <section class="sidebar-section">
+        <h2>Ajustes globais</h2>
+        <div class="control">
+          <label for="rotation">Rotação</label>
+          <div class="rotation-control">
+            <button id="rotationLeft" class="rotation-step" type="button" title="Rotacionar -90°">⬅️</button>
+            <input type="range" id="rotation" min="-180" max="180" value="0" step="1">
+            <button id="rotationRight" class="rotation-step" type="button" title="Rotacionar +90°">➡️</button>
+          </div>
+          <div class="control-value"><span id="rotationValue">0°</span></div>
+        </div>
+        <div class="control">
+          <label for="tolerance">Tolerância do recorte</label>
+          <input type="range" id="tolerance" min="0" max="255" value="30" step="1">
+          <div class="control-value"><span id="toleranceValue">30</span></div>
+        </div>
+        <div class="bulk-actions">
+          <button id="applySelected" class="primary">Aplicar nos selecionados</button>
+          <button id="restoreSelected" class="ghost">Restaurar selecionados</button>
+        </div>
+      </section>
+      <section class="sidebar-section">
+        <h2>Downloads</h2>
+        <button id="downloadSelected" class="primary">Baixar selecionados</button>
+        <button id="downloadAll" class="secondary">Baixar tudo em lote</button>
+      </section>
+    </aside>
+
+    <main class="main-content">
+      <header class="toolbar">
+        <div class="toolbar-left">
+          <h2>Biblioteca</h2>
+          <p>Selecione uma imagem para editar. Use o painel lateral para ações em grupo.</p>
+        </div>
+        <div class="view-switch">
+          <button data-view="processed" class="view-btn active">Processada</button>
+          <button data-view="original" class="view-btn">Original</button>
+        </div>
+      </header>
+
+      <section id="gallery" class="gallery">
+        <div class="empty-state">
+          <div class="empty-icon">📷</div>
+          <h3>Importe suas imagens</h3>
+          <p>Comece arrastando seus produtos para cá e veja o still perfeito ganhar vida.</p>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <template id="imageCardTemplate">
+    <article class="image-card">
+      <div class="card-header">
+        <label class="custom-checkbox">
+          <input type="checkbox" class="select-checkbox">
+          <span></span>
+        </label>
+        <div class="filename" data-filename></div>
+        <button class="restore-btn" title="Restaurar alterações">Restaurar</button>
+      </div>
+      <div class="canvas-wrapper">
+        <canvas class="preview-canvas" width="600" height="600"></canvas>
+        <canvas class="overlay-canvas" width="600" height="600"></canvas>
+      </div>
+      <div class="card-controls">
+        <div class="control-inline rotation-inline">
+          <label>Rotação individual</label>
+          <div class="rotation-control">
+            <button class="rotation-step card-rotation-left" type="button" title="-90°">⬅️</button>
+            <input type="range" class="rotation-slider" min="-180" max="180" step="1" value="0">
+            <button class="rotation-step card-rotation-right" type="button" title="+90°">➡️</button>
+          </div>
+        </div>
+        <div class="control-inline">
+          <label>Escala da foto</label>
+          <input type="range" class="scale-slider" min="0.5" max="2.5" step="0.01" value="1">
+        </div>
+        <div class="control-inline">
+          <label>Deslocamento X</label>
+          <input type="range" class="offset-x-slider" min="-1" max="1" step="0.01" value="0">
+        </div>
+        <div class="control-inline">
+          <label>Deslocamento Y</label>
+          <input type="range" class="offset-y-slider" min="-1" max="1" step="0.01" value="0">
+        </div>
+        <div class="control-inline">
+          <label>Tolerância local</label>
+          <input type="range" class="tolerance-slider" min="0" max="255" step="1" value="30">
+        </div>
+        <div class="manual-tools">
+          <div class="tool-group">
+            <button class="tool-btn active" data-tool="wand" type="button">Varinha mágica</button>
+            <button class="tool-btn" data-tool="quick" type="button">Seleção rápida</button>
+            <button class="tool-btn" data-tool="object" type="button">Seleção de objeto</button>
+          </div>
+          <div class="tool-group">
+            <button class="mode-btn active" data-mode="add" type="button">Manter</button>
+            <button class="mode-btn" data-mode="erase" type="button">Remover</button>
+          </div>
+          <div class="control-inline">
+            <label>Tamanho da ferramenta</label>
+            <input type="range" class="tool-size-slider" min="5" max="240" step="1" value="80">
+          </div>
+        </div>
+        <div class="layer-grid">
+          <label>
+            Camada Largura
+            <input type="number" class="layer-width" min="200" max="4000" value="1200">
+          </label>
+          <label>
+            Camada Altura
+            <input type="number" class="layer-height" min="200" max="4000" value="1200">
+          </label>
+        </div>
+      </div>
+      <div class="card-footer">
+        <button class="download-btn">Baixar</button>
+        <button class="toggle-btn" data-state="processed">Ver original</button>
+      </div>
+    </article>
+  </template>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1156 @@
+const state = {
+  items: [],
+  ratio: '1:1',
+  customWidth: 1200,
+  customHeight: 1200,
+  rotation: 0,
+  tolerance: 30,
+  viewMode: 'processed'
+};
+
+const dom = {
+  fileInput: document.getElementById('fileInput'),
+  dropZone: document.getElementById('dropZone'),
+  gallery: document.getElementById('gallery'),
+  ratioButtons: document.getElementById('ratioButtons'),
+  customWidth: document.getElementById('customWidth'),
+  customHeight: document.getElementById('customHeight'),
+  rotation: document.getElementById('rotation'),
+  rotationValue: document.getElementById('rotationValue'),
+  rotationLeft: document.getElementById('rotationLeft'),
+  rotationRight: document.getElementById('rotationRight'),
+  tolerance: document.getElementById('tolerance'),
+  toleranceValue: document.getElementById('toleranceValue'),
+  applySelected: document.getElementById('applySelected'),
+  restoreSelected: document.getElementById('restoreSelected'),
+  downloadSelected: document.getElementById('downloadSelected'),
+  downloadAll: document.getElementById('downloadAll'),
+  viewSwitch: document.querySelector('.view-switch'),
+  viewButtons: document.querySelectorAll('.view-btn'),
+  template: document.getElementById('imageCardTemplate')
+};
+
+const ratios = {
+  '1:1': [1, 1],
+  '4:5': [4, 5],
+  '16:9': [16, 9],
+  '3:4': [3, 4],
+  '5:2': [5, 2]
+};
+
+function createId() {
+  return `item-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function cloneSettings(settings) {
+  return JSON.parse(JSON.stringify(settings));
+}
+
+function formatName(name) {
+  if (name.length < 32) return name;
+  return name.slice(0, 20) + '…' + name.slice(-8);
+}
+
+function showEmptyState(show) {
+  const existing = dom.gallery.querySelector('.empty-state');
+  if (!existing) return;
+  existing.style.display = show ? 'flex' : 'none';
+}
+
+function loadFiles(files) {
+  const imageFiles = Array.from(files).filter((file) => /image\/(png|jpeg|jpg|webp|gif)/.test(file.type));
+  if (!imageFiles.length) return;
+  showEmptyState(false);
+
+  imageFiles.forEach((file) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => addImageItem(file, img);
+      img.src = reader.result;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function addImageItem(file, image) {
+  const id = createId();
+  const initialLayerWidth = state.customWidth;
+  const initialLayerHeight = computeHeightFromRatio(state.ratio, state.customWidth, state.customHeight) || state.customHeight;
+
+  const settings = {
+    ratio: state.ratio,
+    customWidth: state.customWidth,
+    customHeight: initialLayerHeight,
+    layerWidth: initialLayerWidth,
+    layerHeight: initialLayerHeight,
+    rotation: state.rotation,
+    tolerance: state.tolerance,
+    scale: 1,
+    offsetX: 0,
+    offsetY: 0
+  };
+
+  const card = dom.template.content.firstElementChild.cloneNode(true);
+  const previewCanvas = card.querySelector('.preview-canvas');
+  const overlayCanvas = card.querySelector('.overlay-canvas');
+
+  const originalCanvas = document.createElement('canvas');
+  originalCanvas.width = image.width;
+  originalCanvas.height = image.height;
+  const originalCtx = originalCanvas.getContext('2d');
+  originalCtx.drawImage(image, 0, 0);
+  const originalImageData = originalCtx.getImageData(0, 0, image.width, image.height);
+
+  const manualOverlayCanvas = document.createElement('canvas');
+  manualOverlayCanvas.width = image.width;
+  manualOverlayCanvas.height = image.height;
+
+  card.dataset.id = id;
+  card.querySelector('[data-filename]').textContent = formatName(file.name);
+  card.querySelector('.layer-width').value = initialLayerWidth;
+  card.querySelector('.layer-height').value = initialLayerHeight;
+
+  const item = {
+    id,
+    file,
+    name: file.name,
+    image,
+    settings,
+    initialSettings: cloneSettings(settings),
+    elements: {
+      card,
+      previewCanvas,
+      overlayCanvas,
+      checkbox: card.querySelector('.select-checkbox'),
+      rotationSlider: card.querySelector('.rotation-slider'),
+      rotationLeftBtn: card.querySelector('.card-rotation-left'),
+      rotationRightBtn: card.querySelector('.card-rotation-right'),
+      scaleSlider: card.querySelector('.scale-slider'),
+      offsetXSlider: card.querySelector('.offset-x-slider'),
+      offsetYSlider: card.querySelector('.offset-y-slider'),
+      toleranceSlider: card.querySelector('.tolerance-slider'),
+      toolButtons: card.querySelectorAll('.tool-btn'),
+      modeButtons: card.querySelectorAll('.mode-btn'),
+      toolSizeSlider: card.querySelector('.tool-size-slider'),
+      layerWidthInput: card.querySelector('.layer-width'),
+      layerHeightInput: card.querySelector('.layer-height'),
+      downloadBtn: card.querySelector('.download-btn'),
+      toggleBtn: card.querySelector('.toggle-btn'),
+      restoreBtn: card.querySelector('.restore-btn')
+    },
+    originalImageData,
+    manualMask: new Int8Array(image.width * image.height),
+    manualOverlayCanvas,
+    manualOverlayDirty: true,
+    manualHasEdits: false,
+    manualState: {
+      tool: 'wand',
+      mode: 'add',
+      size: 80,
+      tolerance: state.tolerance,
+      pointerActive: false,
+      rectStart: null,
+      rectCurrent: null
+    }
+  };
+
+  bindCardEvents(item);
+  state.items.push(item);
+  dom.gallery.appendChild(card);
+  updatePreview(item);
+}
+
+function computeHeightFromRatio(ratio, width, fallbackHeight) {
+  if (!ratio || ratio === 'free') return fallbackHeight;
+  const [rw, rh] = ratios[ratio];
+  return Math.round((width * rh) / rw);
+}
+
+function bindCardEvents(item) {
+  const {
+    rotationSlider,
+    rotationLeftBtn,
+    rotationRightBtn,
+    scaleSlider,
+    offsetXSlider,
+    offsetYSlider,
+    toleranceSlider,
+    toolButtons,
+    modeButtons,
+    toolSizeSlider,
+    layerWidthInput,
+    layerHeightInput,
+    downloadBtn,
+    toggleBtn,
+    restoreBtn,
+    checkbox
+  } = item.elements;
+
+  rotationSlider.value = item.settings.rotation;
+  scaleSlider.value = item.settings.scale;
+  offsetXSlider.value = item.settings.offsetX;
+  offsetYSlider.value = item.settings.offsetY;
+  toleranceSlider.value = item.manualState.tolerance;
+  toolSizeSlider.value = item.manualState.size;
+
+  rotationSlider.addEventListener('input', () => {
+    item.settings.rotation = parseInt(rotationSlider.value, 10);
+    updatePreview(item);
+  });
+
+  rotationLeftBtn.addEventListener('click', () => {
+    item.settings.rotation = normalizeAngle(item.settings.rotation - 90);
+    rotationSlider.value = item.settings.rotation;
+    updatePreview(item);
+  });
+
+  rotationRightBtn.addEventListener('click', () => {
+    item.settings.rotation = normalizeAngle(item.settings.rotation + 90);
+    rotationSlider.value = item.settings.rotation;
+    updatePreview(item);
+  });
+
+  scaleSlider.addEventListener('input', () => {
+    item.settings.scale = parseFloat(scaleSlider.value);
+    updatePreview(item);
+  });
+
+  offsetXSlider.addEventListener('input', () => {
+    item.settings.offsetX = parseFloat(offsetXSlider.value);
+    updatePreview(item);
+  });
+
+  offsetYSlider.addEventListener('input', () => {
+    item.settings.offsetY = parseFloat(offsetYSlider.value);
+    updatePreview(item);
+  });
+
+  toleranceSlider.addEventListener('input', () => {
+    item.manualState.tolerance = parseInt(toleranceSlider.value, 10);
+  });
+
+  toolSizeSlider.addEventListener('input', () => {
+    item.manualState.size = parseInt(toolSizeSlider.value, 10);
+  });
+
+  toolButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      toolButtons.forEach((btn) => btn.classList.remove('active'));
+      button.classList.add('active');
+      item.manualState.tool = button.dataset.tool;
+      item.manualState.pointerActive = false;
+      item.manualState.rectStart = null;
+      item.manualState.rectCurrent = null;
+      requestAnimationFrame(() => drawOriginalOverlay(item));
+    });
+  });
+
+  modeButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      modeButtons.forEach((btn) => btn.classList.remove('active'));
+      button.classList.add('active');
+      item.manualState.mode = button.dataset.mode;
+    });
+  });
+
+  layerWidthInput.addEventListener('change', () => {
+    item.settings.layerWidth = clamp(parseInt(layerWidthInput.value, 10), 200, 4000);
+    layerWidthInput.value = item.settings.layerWidth;
+    updatePreview(item);
+  });
+
+  layerHeightInput.addEventListener('change', () => {
+    item.settings.layerHeight = clamp(parseInt(layerHeightInput.value, 10), 200, 4000);
+    layerHeightInput.value = item.settings.layerHeight;
+    updatePreview(item);
+  });
+
+  downloadBtn.addEventListener('click', () => downloadItem(item));
+
+  toggleBtn.addEventListener('click', () => {
+    item.showOriginal = !item.showOriginal;
+    toggleBtn.textContent = item.showOriginal ? 'Ver processada' : 'Ver original';
+    renderCardMode(item);
+  });
+
+  restoreBtn.addEventListener('click', () => {
+    restoreItem(item);
+  });
+
+  checkbox.addEventListener('change', () => {
+    item.selected = checkbox.checked;
+    item.elements.card.classList.toggle('selected', item.selected);
+  });
+
+  overlayCanvas.addEventListener('pointerdown', (event) => handleManualPointerDown(item, event));
+  overlayCanvas.addEventListener('pointermove', (event) => handleManualPointerMove(item, event));
+  overlayCanvas.addEventListener('pointerup', (event) => handleManualPointerUp(item, event));
+  overlayCanvas.addEventListener('pointerleave', (event) => handleManualPointerUp(item, event));
+  overlayCanvas.addEventListener('pointercancel', () => handleManualPointerCancel(item));
+  overlayCanvas.addEventListener('lostpointercapture', () => handleManualPointerCancel(item));
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normalizeAngle(angle) {
+  let result = angle;
+  while (result > 180) result -= 360;
+  while (result < -180) result += 360;
+  return result;
+}
+
+function renderCardMode(item) {
+  const showOriginal = state.viewMode === 'original' || item.showOriginal;
+  item.elements.card.classList.toggle('show-original', showOriginal);
+}
+
+function restoreItem(item) {
+  item.settings = cloneSettings(item.initialSettings);
+  item.elements.rotationSlider.value = item.settings.rotation;
+  item.manualState.tool = 'wand';
+  item.manualState.mode = 'add';
+  item.manualState.tolerance = state.tolerance;
+  item.manualState.size = 80;
+  item.manualState.pointerActive = false;
+  item.manualState.rectStart = null;
+  item.manualState.rectCurrent = null;
+  item.manualMask.fill(0);
+  item.manualHasEdits = false;
+  item.manualOverlayDirty = true;
+  clearManualOverlayCanvas(item);
+  item.elements.toolButtons.forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.tool === 'wand');
+  });
+  item.elements.modeButtons.forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.mode === 'add');
+  });
+  item.elements.toleranceSlider.value = item.manualState.tolerance;
+  item.elements.toolSizeSlider.value = item.manualState.size;
+  Object.assign(item.elements.scaleSlider, { value: item.settings.scale });
+  Object.assign(item.elements.offsetXSlider, { value: item.settings.offsetX });
+  Object.assign(item.elements.offsetYSlider, { value: item.settings.offsetY });
+  item.elements.layerWidthInput.value = item.settings.layerWidth;
+  item.elements.layerHeightInput.value = item.settings.layerHeight;
+  item.showOriginal = false;
+  item.elements.toggleBtn.textContent = 'Ver original';
+  maskCache.delete(item.image);
+  updatePreview(item);
+}
+
+async function downloadItem(item) {
+  await ensurePreviewUpToDate(item);
+  const blob = await canvasToBlob(item.elements.previewCanvas);
+  if (blob) {
+    saveAs(blob, createDownloadName(item.name));
+  }
+}
+
+function createDownloadName(name) {
+  const base = name.replace(/\.[^.]+$/, '');
+  return `${base}-cutpro.png`;
+}
+
+function canvasToBlob(canvas) {
+  return new Promise((resolve) => canvas.toBlob(resolve, 'image/png', 1));
+}
+
+function ensurePreviewUpToDate(item) {
+  return new Promise((resolve) => {
+    updatePreview(item, resolve);
+  });
+}
+
+function updatePreview(item, callback) {
+  requestAnimationFrame(() => {
+    const { previewCanvas, overlayCanvas } = item.elements;
+    const { layerWidth, layerHeight } = item.settings;
+    if (!layerWidth || !layerHeight) return;
+
+    previewCanvas.width = layerWidth;
+    previewCanvas.height = layerHeight;
+    overlayCanvas.width = layerWidth;
+    overlayCanvas.height = layerHeight;
+
+    drawProcessedCanvas(item);
+    drawOriginalOverlay(item);
+    renderCardMode(item);
+    if (callback) callback();
+  });
+}
+
+function drawProcessedCanvas(item) {
+  const canvas = item.elements.previewCanvas;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const processed = getCompositeCanvas(item);
+  const baseScale = Math.min(canvas.width / processed.width, canvas.height / processed.height);
+  const finalScale = baseScale * item.settings.scale;
+  const offsetX = item.settings.offsetX * canvas.width * 0.4;
+  const offsetY = item.settings.offsetY * canvas.height * 0.4;
+
+  ctx.save();
+  ctx.translate(canvas.width / 2 + offsetX, canvas.height / 2 + offsetY);
+  ctx.rotate((item.settings.rotation * Math.PI) / 180);
+  ctx.scale(finalScale, finalScale);
+  ctx.drawImage(processed, -processed.width / 2, -processed.height / 2);
+  ctx.restore();
+}
+
+function drawOriginalOverlay(item) {
+  const canvas = item.elements.overlayCanvas;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const { image } = item;
+  const baseScale = Math.min(canvas.width / image.width, canvas.height / image.height);
+  const finalScale = baseScale * item.settings.scale;
+  const offsetX = item.settings.offsetX * canvas.width * 0.4;
+  const offsetY = item.settings.offsetY * canvas.height * 0.4;
+
+  const showOriginal = state.viewMode === 'original' || item.showOriginal;
+  if (showOriginal) {
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  ctx.save();
+  ctx.translate(canvas.width / 2 + offsetX, canvas.height / 2 + offsetY);
+  ctx.rotate((item.settings.rotation * Math.PI) / 180);
+  ctx.scale(finalScale, finalScale);
+  if (showOriginal) {
+    ctx.drawImage(image, -image.width / 2, -image.height / 2);
+  }
+
+  const overlay = ensureManualOverlay(item);
+  if (overlay) {
+    ctx.drawImage(overlay, -image.width / 2, -image.height / 2);
+  }
+
+  if (item.manualState.tool === 'object' && item.manualState.rectStart && item.manualState.rectCurrent) {
+    const { rectStart, rectCurrent } = item.manualState;
+    const x1 = rectStart.x - image.width / 2;
+    const y1 = rectStart.y - image.height / 2;
+    const x2 = rectCurrent.x - image.width / 2;
+    const y2 = rectCurrent.y - image.height / 2;
+    const width = x2 - x1;
+    const height = y2 - y1;
+    ctx.save();
+    ctx.setLineDash([12 / finalScale, 8 / finalScale]);
+    ctx.lineWidth = 3 / finalScale;
+    ctx.strokeStyle = item.manualState.mode === 'add' ? 'rgba(59, 130, 246, 0.8)' : 'rgba(239, 68, 68, 0.8)';
+    ctx.strokeRect(x1, y1, width, height);
+    ctx.restore();
+  }
+  ctx.restore();
+}
+
+const maskCache = new WeakMap();
+
+function getMaskCanvas(item) {
+  const cacheKey = `${item.settings.tolerance}|${item.image.src}`;
+  let cached = maskCache.get(item.image);
+  if (cached && cached.key === cacheKey) {
+    return cached.canvas;
+  }
+
+  const { image } = item;
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(image, 0, 0);
+  removeBackground(ctx, item.settings.tolerance);
+
+  maskCache.set(item.image, { key: cacheKey, canvas });
+  return canvas;
+}
+
+function getCompositeCanvas(item) {
+  const base = getMaskCanvas(item);
+  if (!item.manualHasEdits) return base;
+  const canvas = document.createElement('canvas');
+  canvas.width = base.width;
+  canvas.height = base.height;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(base, 0, 0);
+  applyManualMask(canvas, item);
+  return canvas;
+}
+
+function applyManualMask(canvas, item) {
+  if (!item.manualMask || !item.originalImageData) return;
+  const ctx = canvas.getContext('2d');
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+  const original = item.originalImageData.data;
+  const manualMask = item.manualMask;
+  let changed = false;
+
+  for (let i = 0; i < manualMask.length; i += 1) {
+    const val = manualMask[i];
+    if (!val) continue;
+    const offset = i * 4;
+    if (val === 1) {
+      data[offset] = original[offset];
+      data[offset + 1] = original[offset + 1];
+      data[offset + 2] = original[offset + 2];
+      data[offset + 3] = 255;
+      changed = true;
+    } else if (val === -1) {
+      if (data[offset + 3] !== 0) {
+        data[offset + 3] = 0;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    ctx.putImageData(imageData, 0, 0);
+  }
+}
+
+function markManualEdits(item) {
+  item.manualHasEdits = true;
+  item.manualOverlayDirty = true;
+}
+
+function clearManualOverlayCanvas(item) {
+  if (!item.manualOverlayCanvas) return;
+  const ctx = item.manualOverlayCanvas.getContext('2d');
+  ctx.clearRect(0, 0, item.manualOverlayCanvas.width, item.manualOverlayCanvas.height);
+}
+
+function ensureManualOverlay(item) {
+  if (!item.manualHasEdits) return null;
+  if (!item.manualOverlayCanvas) return null;
+  if (!item.manualOverlayDirty) return item.manualOverlayCanvas;
+
+  const canvas = item.manualOverlayCanvas;
+  const ctx = canvas.getContext('2d');
+  const overlayData = ctx.createImageData(canvas.width, canvas.height);
+  const data = overlayData.data;
+  const mask = item.manualMask;
+
+  for (let i = 0; i < mask.length; i += 1) {
+    const val = mask[i];
+    if (!val) continue;
+    const offset = i * 4;
+    if (val === 1) {
+      data[offset] = 59;
+      data[offset + 1] = 130;
+      data[offset + 2] = 246;
+      data[offset + 3] = 140;
+    } else if (val === -1) {
+      data[offset] = 239;
+      data[offset + 1] = 68;
+      data[offset + 2] = 68;
+      data[offset + 3] = 160;
+    }
+  }
+
+  ctx.putImageData(overlayData, 0, 0);
+  item.manualOverlayDirty = false;
+  return canvas;
+}
+
+function mapCanvasPointToImage(item, canvasX, canvasY) {
+  const canvas = item.elements.overlayCanvas;
+  const { image } = item;
+  if (!image || !canvas.width || !canvas.height) return { x: NaN, y: NaN };
+  const baseScale = Math.min(canvas.width / image.width, canvas.height / image.height);
+  const finalScale = baseScale * item.settings.scale;
+  const offsetX = item.settings.offsetX * canvas.width * 0.4;
+  const offsetY = item.settings.offsetY * canvas.height * 0.4;
+  const cx = canvas.width / 2 + offsetX;
+  const cy = canvas.height / 2 + offsetY;
+
+  const dx = canvasX - cx;
+  const dy = canvasY - cy;
+  const angle = (-item.settings.rotation * Math.PI) / 180;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const rx = dx * cos - dy * sin;
+  const ry = dx * sin + dy * cos;
+
+  const x = rx / finalScale + image.width / 2;
+  const y = ry / finalScale + image.height / 2;
+  return { x, y };
+}
+
+function getPointerImageCoords(item, event) {
+  const canvas = item.elements.overlayCanvas;
+  const rect = canvas.getBoundingClientRect();
+  const canvasX = ((event.clientX - rect.left) / rect.width) * canvas.width;
+  const canvasY = ((event.clientY - rect.top) / rect.height) * canvas.height;
+  if (Number.isNaN(canvasX) || Number.isNaN(canvasY)) return null;
+  if (canvasX < 0 || canvasY < 0 || canvasX > canvas.width || canvasY > canvas.height) return null;
+  const { x, y } = mapCanvasPointToImage(item, canvasX, canvasY);
+  if (Number.isNaN(x) || Number.isNaN(y)) return null;
+  const clampedX = clamp(x, 0, item.image.width - 1);
+  const clampedY = clamp(y, 0, item.image.height - 1);
+  return { x: clampedX, y: clampedY };
+}
+
+function handleManualPointerDown(item, event) {
+  if (!item.manualState) return;
+  event.preventDefault();
+  const coords = getPointerImageCoords(item, event);
+  if (!coords) return;
+  const tool = item.manualState.tool;
+
+  if (tool === 'wand') {
+    applyMagicWand(item, coords.x, coords.y);
+    updatePreview(item);
+    return;
+  }
+
+  item.manualState.pointerActive = true;
+  if (tool === 'quick') {
+    applyQuickSelection(item, coords.x, coords.y);
+    updatePreview(item);
+  }
+
+  if (tool === 'object') {
+    item.manualState.rectStart = coords;
+    item.manualState.rectCurrent = coords;
+    requestAnimationFrame(() => drawOriginalOverlay(item));
+  }
+
+  event.currentTarget.setPointerCapture(event.pointerId);
+}
+
+function handleManualPointerMove(item, event) {
+  if (!item.manualState?.pointerActive) return;
+  const coords = getPointerImageCoords(item, event);
+  if (!coords) return;
+  if (item.manualState.tool === 'quick') {
+    applyQuickSelection(item, coords.x, coords.y);
+    updatePreview(item);
+  } else if (item.manualState.tool === 'object') {
+    item.manualState.rectCurrent = coords;
+    requestAnimationFrame(() => drawOriginalOverlay(item));
+  }
+}
+
+function handleManualPointerUp(item, event) {
+  if (!item.manualState) return;
+  if (item.manualState.tool === 'object' && item.manualState.pointerActive) {
+    const coords = getPointerImageCoords(item, event);
+    if (coords) {
+      item.manualState.rectCurrent = coords;
+    }
+    finalizeObjectSelection(item);
+    updatePreview(item);
+  }
+
+  if (item.manualState.tool === 'quick' && item.manualState.pointerActive) {
+    updatePreview(item);
+  }
+
+  item.manualState.pointerActive = false;
+  if (event && event.currentTarget?.hasPointerCapture(event.pointerId)) {
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  }
+}
+
+function handleManualPointerCancel(item) {
+  if (!item.manualState) return;
+  item.manualState.pointerActive = false;
+  if (item.manualState.tool === 'object') {
+    item.manualState.rectStart = null;
+    item.manualState.rectCurrent = null;
+    requestAnimationFrame(() => drawOriginalOverlay(item));
+  }
+}
+
+function applyMagicWand(item, x, y) {
+  const width = item.image.width;
+  const height = item.image.height;
+  const px = Math.round(clamp(x, 0, width - 1));
+  const py = Math.round(clamp(y, 0, height - 1));
+  const idxStart = py * width + px;
+  const manualMask = item.manualMask;
+  const data = item.originalImageData.data;
+  const offsetStart = idxStart * 4;
+  const sr = data[offsetStart];
+  const sg = data[offsetStart + 1];
+  const sb = data[offsetStart + 2];
+  const tolerance = item.manualState.tolerance;
+  const toleranceSq = tolerance * tolerance * 1.5;
+  const targetValue = item.manualState.mode === 'erase' ? -1 : 1;
+  const visited = new Uint8Array(width * height);
+  const stack = [idxStart];
+  let changed = false;
+
+  while (stack.length) {
+    const idx = stack.pop();
+    if (visited[idx]) continue;
+    visited[idx] = 1;
+    const offset = idx * 4;
+    const dr = data[offset] - sr;
+    const dg = data[offset + 1] - sg;
+    const db = data[offset + 2] - sb;
+    const diff = dr * dr + dg * dg + db * db;
+    if (diff > toleranceSq) continue;
+    if (manualMask[idx] !== targetValue) {
+      manualMask[idx] = targetValue;
+      changed = true;
+    }
+    const ix = idx % width;
+    const iy = (idx / width) | 0;
+    if (ix > 0) stack.push(idx - 1);
+    if (ix < width - 1) stack.push(idx + 1);
+    if (iy > 0) stack.push(idx - width);
+    if (iy < height - 1) stack.push(idx + width);
+  }
+
+  if (changed) {
+    markManualEdits(item);
+  }
+}
+
+function applyQuickSelection(item, x, y) {
+  const width = item.image.width;
+  const height = item.image.height;
+  const cx = Math.round(clamp(x, 0, width - 1));
+  const cy = Math.round(clamp(y, 0, height - 1));
+  const data = item.originalImageData.data;
+  const manualMask = item.manualMask;
+  const sampleOffset = (cy * width + cx) * 4;
+  const sr = data[sampleOffset];
+  const sg = data[sampleOffset + 1];
+  const sb = data[sampleOffset + 2];
+  const tolerance = item.manualState.tolerance;
+  const toleranceSq = tolerance * tolerance * 1.2;
+  const radius = Math.max(2, Math.round(item.manualState.size));
+  const radiusSq = radius * radius;
+  const value = item.manualState.mode === 'erase' ? -1 : 1;
+  const xStart = Math.max(0, cx - radius);
+  const xEnd = Math.min(width - 1, cx + radius);
+  const yStart = Math.max(0, cy - radius);
+  const yEnd = Math.min(height - 1, cy + radius);
+  let changed = false;
+
+  for (let yy = yStart; yy <= yEnd; yy += 1) {
+    const dy = yy - cy;
+    for (let xx = xStart; xx <= xEnd; xx += 1) {
+      const dx = xx - cx;
+      if (dx * dx + dy * dy > radiusSq) continue;
+      const idx = yy * width + xx;
+      const offset = idx * 4;
+      const dr = data[offset] - sr;
+      const dg = data[offset + 1] - sg;
+      const db = data[offset + 2] - sb;
+      const diff = dr * dr + dg * dg + db * db;
+      if (diff > toleranceSq) continue;
+      if (manualMask[idx] !== value) {
+        manualMask[idx] = value;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    markManualEdits(item);
+  }
+}
+
+function finalizeObjectSelection(item) {
+  const { rectStart, rectCurrent } = item.manualState;
+  if (!rectStart || !rectCurrent) return;
+
+  const width = item.image.width;
+  const height = item.image.height;
+  const x1 = clamp(Math.min(rectStart.x, rectCurrent.x), 0, width - 1);
+  const x2 = clamp(Math.max(rectStart.x, rectCurrent.x), 0, width - 1);
+  const y1 = clamp(Math.min(rectStart.y, rectCurrent.y), 0, height - 1);
+  const y2 = clamp(Math.max(rectStart.y, rectCurrent.y), 0, height - 1);
+  const manualMask = item.manualMask;
+  const value = item.manualState.mode === 'erase' ? -1 : 1;
+  let changed = false;
+
+  for (let yy = Math.floor(y1); yy <= Math.ceil(y2); yy += 1) {
+    for (let xx = Math.floor(x1); xx <= Math.ceil(x2); xx += 1) {
+      const idx = yy * width + xx;
+      if (manualMask[idx] !== value) {
+        manualMask[idx] = value;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    markManualEdits(item);
+  }
+
+  item.manualState.rectStart = null;
+  item.manualState.rectCurrent = null;
+}
+
+function removeBackground(ctx, tolerance) {
+  const { width, height } = ctx.canvas;
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  const visited = new Uint8Array(width * height);
+  const queue = [];
+
+  const bgColor = sampleEdgeColor(data, width, height);
+  const toleranceSq = tolerance * tolerance * 1.2;
+
+  function tryAdd(x, y) {
+    if (x < 0 || y < 0 || x >= width || y >= height) return;
+    const idx = y * width + x;
+    if (visited[idx]) return;
+    const offset = idx * 4;
+    const dr = data[offset] - bgColor[0];
+    const dg = data[offset + 1] - bgColor[1];
+    const db = data[offset + 2] - bgColor[2];
+    const diff = dr * dr + dg * dg + db * db;
+    if (diff <= toleranceSq) {
+      visited[idx] = 1;
+      queue.push(idx);
+    }
+  }
+
+  for (let x = 0; x < width; x++) {
+    tryAdd(x, 0);
+    tryAdd(x, height - 1);
+  }
+  for (let y = 0; y < height; y++) {
+    tryAdd(0, y);
+    tryAdd(width - 1, y);
+  }
+
+  while (queue.length) {
+    const idx = queue.shift();
+    const offset = idx * 4;
+    data[offset + 3] = 0;
+    const x = idx % width;
+    const y = (idx / width) | 0;
+    tryAdd(x + 1, y);
+    tryAdd(x - 1, y);
+    tryAdd(x, y + 1);
+    tryAdd(x, y - 1);
+  }
+
+  refineAlpha(imageData, width, height);
+  ctx.putImageData(imageData, 0, 0);
+}
+
+function sampleEdgeColor(data, width, height) {
+  let totalR = 0;
+  let totalG = 0;
+  let totalB = 0;
+  let count = 0;
+  const stepX = Math.max(1, Math.floor(width / 40));
+  const stepY = Math.max(1, Math.floor(height / 40));
+
+  for (let x = 0; x < width; x += stepX) {
+    const top = (0 * width + x) * 4;
+    const bottom = ((height - 1) * width + x) * 4;
+    totalR += data[top];
+    totalG += data[top + 1];
+    totalB += data[top + 2];
+    totalR += data[bottom];
+    totalG += data[bottom + 1];
+    totalB += data[bottom + 2];
+    count += 2;
+  }
+
+  for (let y = 0; y < height; y += stepY) {
+    const left = (y * width + 0) * 4;
+    const right = (y * width + (width - 1)) * 4;
+    totalR += data[left];
+    totalG += data[left + 1];
+    totalB += data[left + 2];
+    totalR += data[right];
+    totalG += data[right + 1];
+    totalB += data[right + 2];
+    count += 2;
+  }
+
+  return [totalR / count || 255, totalG / count || 255, totalB / count || 255];
+}
+
+function refineAlpha(imageData, width, height) {
+  const length = width * height;
+  const alphaMask = new Uint8Array(length);
+  const data = imageData.data;
+
+  for (let i = 0; i < length; i += 1) {
+    alphaMask[i] = data[i * 4 + 3] > 0 ? 1 : 0;
+  }
+
+  const dilated = new Uint8Array(length);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = y * width + x;
+      let found = 0;
+      for (let dy = -1; dy <= 1 && !found; dy += 1) {
+        for (let dx = -1; dx <= 1; dx += 1) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+          if (alphaMask[ny * width + nx]) {
+            found = 1;
+            break;
+          }
+        }
+      }
+      dilated[idx] = found;
+    }
+  }
+
+  const closed = new Uint8Array(length);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = y * width + x;
+      let keep = 1;
+      for (let dy = -1; dy <= 1 && keep; dy += 1) {
+        for (let dx = -1; dx <= 1; dx += 1) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+          if (!dilated[ny * width + nx]) {
+            keep = 0;
+            break;
+          }
+        }
+      }
+      closed[idx] = keep;
+    }
+  }
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = y * width + x;
+      let sum = 0;
+      let count = 0;
+      for (let dy = -1; dy <= 1; dy += 1) {
+        for (let dx = -1; dx <= 1; dx += 1) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+          sum += closed[ny * width + nx];
+          count += 1;
+        }
+      }
+      const value = Math.round((sum / count) * 255);
+      data[idx * 4 + 3] = value;
+    }
+  }
+}
+
+function getSelectedItems() {
+  return state.items.filter((item) => item.selected);
+}
+
+function applySettingsTo(items) {
+  items.forEach((item) => {
+    item.settings.ratio = state.ratio;
+    item.settings.rotation = state.rotation;
+    item.settings.tolerance = state.tolerance;
+    item.settings.customWidth = state.customWidth;
+    item.settings.customHeight = computeHeightFromRatio(state.ratio, state.customWidth, state.customHeight) || state.customHeight;
+
+    const {
+      layerWidthInput,
+      layerHeightInput,
+      scaleSlider,
+      offsetXSlider,
+      offsetYSlider,
+      rotationSlider,
+      toleranceSlider
+    } = item.elements;
+
+    if (state.ratio !== 'free') {
+      item.settings.layerWidth = state.customWidth;
+      item.settings.layerHeight = computeHeightFromRatio(state.ratio, state.customWidth, state.customHeight);
+    } else {
+      item.settings.layerWidth = state.customWidth;
+      item.settings.layerHeight = state.customHeight;
+    }
+
+    layerWidthInput.value = item.settings.layerWidth;
+    layerHeightInput.value = item.settings.layerHeight;
+
+    scaleSlider.value = item.settings.scale;
+    offsetXSlider.value = item.settings.offsetX;
+    offsetYSlider.value = item.settings.offsetY;
+    rotationSlider.value = item.settings.rotation;
+    item.manualState.tolerance = state.tolerance;
+    toleranceSlider.value = item.manualState.tolerance;
+    maskCache.delete(item.image);
+
+    updatePreview(item);
+  });
+}
+
+function restoreItems(items) {
+  items.forEach((item) => {
+    restoreItem(item);
+    item.elements.checkbox.checked = false;
+    item.selected = false;
+  });
+}
+
+async function downloadItems(items) {
+  if (!items.length) return;
+  if (items.length === 1) {
+    await downloadItem(items[0]);
+    return;
+  }
+
+  const zip = new JSZip();
+  for (const item of items) {
+    await ensurePreviewUpToDate(item);
+    const blob = await canvasToBlob(item.elements.previewCanvas);
+    if (blob) {
+      zip.file(createDownloadName(item.name), blob);
+    }
+  }
+
+  const content = await zip.generateAsync({ type: 'blob' });
+  saveAs(content, 'cutpro-imagens.zip');
+}
+
+function initRatioButtons() {
+  dom.ratioButtons.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-ratio]');
+    if (!button) return;
+
+    dom.ratioButtons.querySelectorAll('.ratio-btn').forEach((btn) => btn.classList.remove('active'));
+    button.classList.add('active');
+    const ratio = button.dataset.ratio;
+    state.ratio = ratio;
+    if (ratio !== 'free') {
+      const height = computeHeightFromRatio(ratio, state.customWidth, state.customHeight);
+      state.customHeight = height;
+      dom.customHeight.value = height;
+    }
+  });
+}
+
+function initCustomDimensionInputs() {
+  dom.customWidth.addEventListener('change', () => {
+    state.customWidth = clamp(parseInt(dom.customWidth.value, 10) || 1200, 200, 4000);
+    dom.customWidth.value = state.customWidth;
+    if (state.ratio !== 'free') {
+      const height = computeHeightFromRatio(state.ratio, state.customWidth, state.customHeight);
+      state.customHeight = height;
+      dom.customHeight.value = height;
+    }
+  });
+
+  dom.customHeight.addEventListener('change', () => {
+    state.customHeight = clamp(parseInt(dom.customHeight.value, 10) || 1200, 200, 4000);
+    dom.customHeight.value = state.customHeight;
+    if (state.ratio !== 'free') {
+      const height = computeHeightFromRatio(state.ratio, state.customWidth, state.customHeight);
+      state.customHeight = height;
+      dom.customHeight.value = height;
+    }
+  });
+}
+
+function initGlobalControls() {
+  dom.rotation.addEventListener('input', () => {
+    state.rotation = parseInt(dom.rotation.value, 10);
+    dom.rotationValue.textContent = `${state.rotation}°`;
+  });
+
+  dom.rotationLeft.addEventListener('click', () => {
+    state.rotation = normalizeAngle(state.rotation - 90);
+    dom.rotation.value = state.rotation;
+    dom.rotationValue.textContent = `${state.rotation}°`;
+  });
+
+  dom.rotationRight.addEventListener('click', () => {
+    state.rotation = normalizeAngle(state.rotation + 90);
+    dom.rotation.value = state.rotation;
+    dom.rotationValue.textContent = `${state.rotation}°`;
+  });
+
+  dom.tolerance.addEventListener('input', () => {
+    state.tolerance = parseInt(dom.tolerance.value, 10);
+    dom.toleranceValue.textContent = state.tolerance;
+  });
+
+  dom.applySelected.addEventListener('click', () => {
+    const selected = getSelectedItems();
+    applySettingsTo(selected);
+  });
+
+  dom.restoreSelected.addEventListener('click', () => {
+    const selected = getSelectedItems();
+    restoreItems(selected);
+  });
+
+  dom.downloadSelected.addEventListener('click', () => {
+    const selected = getSelectedItems();
+    downloadItems(selected);
+  });
+
+  dom.downloadAll.addEventListener('click', () => {
+    downloadItems(state.items);
+  });
+}
+
+function initDropZone() {
+  ['dragenter', 'dragover'].forEach((eventName) => {
+    dom.dropZone.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      dom.dropZone.classList.add('dragover');
+    });
+  });
+
+  ['dragleave', 'drop'].forEach((eventName) => {
+    dom.dropZone.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      dom.dropZone.classList.remove('dragover');
+    });
+  });
+
+  dom.dropZone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    const files = event.dataTransfer?.files;
+    if (files) loadFiles(files);
+  });
+}
+
+function initFileInput() {
+  dom.fileInput.addEventListener('change', () => {
+    if (dom.fileInput.files) {
+      loadFiles(dom.fileInput.files);
+      dom.fileInput.value = '';
+    }
+  });
+}
+
+function initViewSwitch() {
+  dom.viewSwitch.addEventListener('click', (event) => {
+    const button = event.target.closest('.view-btn');
+    if (!button) return;
+
+    dom.viewButtons.forEach((btn) => btn.classList.remove('active'));
+    button.classList.add('active');
+    state.viewMode = button.dataset.view;
+    state.items.forEach((item) => renderCardMode(item));
+  });
+}
+
+function init() {
+  initRatioButtons();
+  initCustomDimensionInputs();
+  initGlobalControls();
+  initDropZone();
+  initFileInput();
+  initViewSwitch();
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,628 @@
+:root {
+  --blue-500: #3B82F6;
+  --blue-400: #60A5FA;
+  --blue-600: #2563EB;
+  --gray-50: #F8FAFC;
+  --gray-100: #F1F5F9;
+  --gray-200: #E2E8F0;
+  --gray-300: #CBD5F5;
+  --gray-600: #475569;
+  --gray-700: #334155;
+  --gray-900: #0F172A;
+  --shadow-lg: 0 20px 45px rgba(15, 23, 42, 0.15);
+  --radius-lg: 24px;
+  --transition: 200ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(59, 130, 246, 0));
+  color: var(--gray-900);
+  min-height: 100vh;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.95), rgba(37, 99, 235, 0.95));
+  color: white;
+  padding: 32px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  overflow-y: auto;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.branding p {
+  margin: 2px 0 0;
+  opacity: 0.8;
+}
+
+.logo-circle {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  font-weight: 700;
+  font-size: 1.5rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.12));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.sidebar-section {
+  background: rgba(15, 23, 42, 0.24);
+  border-radius: 20px;
+  padding: 20px 22px;
+  backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sidebar-section h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.sidebar-section p {
+  margin: 0;
+  line-height: 1.4;
+  font-size: 0.92rem;
+  opacity: 0.85;
+}
+
+.upload-button {
+  background: white;
+  color: var(--blue-600);
+  padding: 12px 18px;
+  border-radius: 16px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+  display: block;
+  transition: transform var(--transition), box-shadow var(--transition);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.2);
+}
+
+.upload-button input {
+  display: none;
+}
+
+.upload-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.25);
+}
+
+.drop-zone {
+  border: 1px dashed rgba(255, 255, 255, 0.6);
+  border-radius: 18px;
+  padding: 28px 16px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.85);
+  transition: background var(--transition), border var(--transition);
+}
+
+.drop-zone.dragover {
+  border-color: white;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.ratio-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.ratio-btn {
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: white;
+  padding: 10px;
+  border-radius: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.ratio-btn.active,
+.ratio-btn:hover {
+  background: white;
+  color: var(--blue-600);
+  transform: translateY(-1px);
+}
+
+.custom-dimensions {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.custom-dimensions label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.custom-dimensions input,
+.layer-grid input,
+.layer-grid label,
+.sidebar input[type="number"] {
+  font-family: inherit;
+}
+
+.custom-dimensions input,
+.layer-grid input {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: none;
+  background: rgba(15, 23, 42, 0.12);
+  color: white;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.rotation-control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.rotation-control input[type="range"] {
+  flex: 1;
+}
+
+.rotation-step {
+  border: none;
+  background: rgba(15, 23, 42, 0.16);
+  color: white;
+  border-radius: 12px;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform var(--transition), background var(--transition), box-shadow var(--transition);
+}
+
+.rotation-step:hover {
+  transform: translateY(-2px);
+  background: rgba(59, 130, 246, 0.35);
+  box-shadow: 0 10px 18px rgba(59, 130, 246, 0.35);
+}
+
+.rotation-inline label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.control input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.3);
+  outline: none;
+}
+
+.control input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: white;
+  border: 2px solid rgba(59, 130, 246, 0.8);
+  cursor: pointer;
+}
+
+.control-value {
+  display: flex;
+  justify-content: flex-end;
+  font-weight: 600;
+  opacity: 0.9;
+}
+
+.bulk-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.primary,
+.secondary,
+.ghost {
+  font-family: inherit;
+  font-weight: 600;
+  border-radius: 16px;
+  padding: 12px 16px;
+  cursor: pointer;
+  border: none;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.primary {
+  background: white;
+  color: var(--blue-600);
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.25);
+}
+
+.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
+}
+
+.secondary:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.ghost {
+  background: transparent;
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.ghost:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.main-content {
+  background: var(--gray-50);
+  padding: 32px 36px;
+  overflow-y: auto;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.toolbar-left h2 {
+  margin: 0 0 4px;
+  font-size: 1.4rem;
+}
+
+.toolbar-left p {
+  margin: 0;
+  color: var(--gray-600);
+}
+
+.view-switch {
+  display: inline-flex;
+  background: white;
+  border-radius: 16px;
+  padding: 4px;
+  box-shadow: var(--shadow-lg);
+}
+
+.view-btn {
+  border: none;
+  padding: 10px 18px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  background: transparent;
+  color: var(--gray-600);
+  transition: background var(--transition), color var(--transition);
+}
+
+.view-btn.active {
+  background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
+  color: white;
+  box-shadow: 0 10px 20px rgba(59, 130, 246, 0.25);
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  background: white;
+  border-radius: var(--radius-lg);
+  padding: 64px 32px;
+  text-align: center;
+  color: var(--gray-600);
+  box-shadow: var(--shadow-lg);
+}
+
+.empty-icon {
+  font-size: 3rem;
+  margin-bottom: 12px;
+}
+
+.image-card {
+  background: white;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.1);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: transform var(--transition), box-shadow var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.image-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.18);
+}
+
+.image-card.selected {
+  box-shadow: 0 25px 65px rgba(59, 130, 246, 0.28);
+  outline: 2px solid rgba(59, 130, 246, 0.65);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.custom-checkbox {
+  position: relative;
+  width: 20px;
+  height: 20px;
+}
+
+.custom-checkbox input {
+  opacity: 0;
+  position: absolute;
+}
+
+.custom-checkbox span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 2px solid var(--gray-200);
+  transition: background var(--transition), border var(--transition);
+}
+
+.custom-checkbox input:checked + span {
+  background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
+  border-color: transparent;
+}
+
+.filename {
+  flex: 1;
+  font-weight: 600;
+  color: var(--gray-700);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.restore-btn {
+  border: none;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--blue-600);
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.canvas-wrapper {
+  position: relative;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(255, 255, 255, 0.9));
+  border-radius: 18px;
+  padding: 16px;
+  display: grid;
+  place-items: center;
+}
+
+.canvas-wrapper canvas {
+  max-width: 100%;
+  border-radius: 14px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  transition: opacity var(--transition);
+}
+
+.overlay-canvas {
+  position: absolute;
+  inset: 16px;
+  opacity: 1;
+  pointer-events: auto;
+  cursor: crosshair;
+}
+
+.manual-tools {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 14px;
+}
+
+.tool-group {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tool-btn,
+.mode-btn {
+  flex: 1;
+  min-width: 120px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: none;
+  background: rgba(15, 23, 42, 0.12);
+  color: var(--gray-800);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+}
+
+.tool-btn.active,
+.mode-btn.active {
+  background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
+  color: white;
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.35);
+}
+
+.tool-btn:hover,
+.mode-btn:hover {
+  transform: translateY(-2px);
+}
+
+.manual-tools .control-inline {
+  margin: 0;
+}
+
+.card-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.control-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.control-inline input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--gray-200);
+}
+
+.control-inline input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--blue-500);
+  box-shadow: 0 4px 10px rgba(59, 130, 246, 0.35);
+}
+
+.layer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.layer-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: var(--gray-700);
+}
+
+.layer-grid input {
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid var(--gray-200);
+}
+
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.download-btn,
+.toggle-btn {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.download-btn {
+  background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
+  color: white;
+  box-shadow: 0 10px 20px rgba(59, 130, 246, 0.35);
+}
+
+.download-btn:hover {
+  transform: translateY(-2px);
+}
+
+.toggle-btn {
+  background: var(--gray-100);
+  color: var(--gray-700);
+}
+
+.toggle-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+}
+
+@media (max-width: 1080px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+}
+
+@media (max-width: 720px) {
+  .main-content {
+    padding: 24px;
+  }
+
+  .gallery {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- add rotation step controls in the sidebar and per-card editor plus manual selection widgets for fine adjustments
- implement wand, quick brush, and object selection masking with independent tolerances and tool sizing that blend manual edits into the processed preview
- refine the automatic background removal with morphological feathering to keep garment edges crisp against the white still backdrop

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d6b0a8e168832a9c7386b8f76cd97e